### PR TITLE
chore: add placeholders for ci steps

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -13,5 +13,6 @@ jobs:
       run: echo Hello, world!
     - name: Run a multi-line script
       run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
+        # Add build steps here
+        # Add test steps here
+        # Add deployment steps here


### PR DESCRIPTION
## Summary
- replace echo commands with build/test/deploy placeholders

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/fr4p31-repo/package.json')

------
https://chatgpt.com/codex/tasks/task_e_688bb574460c83288545ce1c13616d3a